### PR TITLE
「和暦出力機能」の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'bootstrap', '~> 4.1.1'
 gem 'jquery-rails'
+
+gem 'wareki'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,8 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    wareki (1.1.0)
+      ya_kansuji (> 0.0.9, < 2.0.0)
     web-console (4.0.4)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -210,6 +212,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    ya_kansuji (0.2.0)
     zeitwerk (2.4.0)
 
 PLATFORMS
@@ -233,6 +236,7 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data
+  wareki
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -40,6 +40,11 @@ class PostsController < ApplicationController
     else
     render("posts/new")
     end
+
+    #新規投稿のidを取得して和暦に変更したい
+    @id = Post.find_by(id: params[:id])
+    @created_at_wareki = Date.parse(Post.@id.created_at.to_s).strftime("%JF")
+
   end
 
   def edit

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -65,7 +65,7 @@
       </div>
       <br>
     <% end %>
-    
+    <p><%= @created_at_wareki %></p>
   </header>
   
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+    date:
+        formats:
+            default: "%JF"


### PR DESCRIPTION
## 質問
'created_at'を和暦でviewに出力する実装を’app/views/posts/index.html.erb’のページで試しています。
新規投稿の投稿日時が和暦で出力されるようにしたいです。

おそらくcontrollerでcreated_atを和暦変換してviewに送るのだと思うので、実装してみようと試行錯誤していますがエラーになってしまいます。アドバイスいただけるとありがたいです。よろしくお願いします。
